### PR TITLE
Add a SHA256 sum since SHA1 doesn't work anymore

### DIFF
--- a/files/brews/nginx.rb
+++ b/files/brews/nginx.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Nginx < Formula
   homepage 'http://nginx.org/'
   url 'http://nginx.org/download/nginx-1.6.2.tar.gz'
-  sha1 '1a5458bc15acf90eea16353a1dd17285cf97ec35'
+  sha256 'b5608c2959d3e7ad09b20fc8f9e5bd4bc87b3bc8ba5936a513c04ed8f1391a18'
   version '1.6.2-boxen1'
 
   depends_on 'pcre'


### PR DESCRIPTION
/domain @jmileham @while1malloc0

Downloaded the tar manually and checked the SHA1 matched what we had. Then gened the SHA256 and replaced the SHA1

I do want to upgrade our Nginx locally to be a newer version, but I will handle that separately!